### PR TITLE
Conditionally load credentials

### DIFF
--- a/main.go
+++ b/main.go
@@ -350,7 +350,6 @@ func main() {
 		&cli.StringFlag{
 			Name:    "profile, pf",
 			Usage:   "AWS profile (default: 'default')",
-			Value:   "default",
 			EnvVars: []string{"PLUGIN_PROFILE", "AWS_PROFILE", "AWS_DEFAULT_PROFILE"},
 		},
 		&cli.BoolFlag{

--- a/storage/backend/s3/s3.go
+++ b/storage/backend/s3/s3.go
@@ -29,10 +29,20 @@ type Backend struct {
 
 // New creates an S3 backend.
 func New(l log.Logger, c Config, debug bool) (*Backend, error) {
-	cfg, err := config.LoadDefaultConfig(context.TODO(),
-		config.WithRegion(c.Region), 
-		config.WithSharedConfigProfile(c.Profile),
-	)
+
+	var cfg aws.Config
+	var err error
+
+	if c.Profile != "" {
+		cfg, err = config.LoadDefaultConfig(context.TODO(),
+			config.WithRegion(c.Region), 
+			config.WithSharedConfigProfile(c.Profile),
+		)
+	} else {
+		cfg, err = config.LoadDefaultConfig(context.TODO(),
+			config.WithRegion(c.Region), 
+		)
+	}
 
 	if err != nil {
 		level.Error(l).Log("err", err)


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
It was always loading shared credentials based on profile after #1. It is causing an issue on drone an specific drone ci pipeline where the bucket is an different account:

![image](https://user-images.githubusercontent.com/69471461/155217781-f4087040-696e-47e3-8b20-aac13353aa70.png)

## What is the new behavior?
It now will only load the shared credentials based on profile when the profile variable has value, otherwise it will load the default context that already works for drone ci.

## Rollback plan
- [x] Revert this PR
- [ ] Other (please, specify):

## Warnings
N/A

## Evidences
Validated with a RC for `pipeline-cache`

![image](https://user-images.githubusercontent.com/69471461/155218032-7a654482-da76-4933-97e5-0509f731b934.png)

https://drone.eks.klickpages.com.br/Hotmart-Org/saas-send-api/251/1/5
